### PR TITLE
fix: fixes accent colors for blockquote and headings in dark mode

### DIFF
--- a/classless.css
+++ b/classless.css
@@ -94,6 +94,8 @@
     --shadow-color: rgba(0, 0, 0, 0.3);
     --card-bg: #1e293b;
 
+    --gradient-primary: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary-dark) 100%);
+
     /* Dark mode shadows */
     --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.2);
     --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
@@ -266,7 +268,7 @@ pre code {
 }
 
 blockquote {
-    border-left: 4px solid var(--primary);
+    border-left: 4px solid var(--primary-light);
     padding: var(--spacing-base);
     margin-bottom: var(--spacing-base);
     font-style: italic;
@@ -277,6 +279,7 @@ blockquote {
 
 :root[color-scheme="dark"] blockquote {
     background-color: rgba(255, 255, 255, 0.03);
+    border-color: var(--primary-dark);
 }
 
 hr {


### PR DESCRIPTION
Dark mode has incorrect accents. This PR updates the stylesheet to create light-color accents when in dark mode for headings and blockquotes.

**before**
![Screenshot 2025-03-18 at 10 11 06 AM](https://github.com/user-attachments/assets/0dcd61f9-56a7-48d7-a07b-95ba0924398b)

**after**
![Screenshot 2025-03-18 at 10 17 56 AM](https://github.com/user-attachments/assets/165b3a4b-f739-4a4a-ba92-bcdf34a29e67)
